### PR TITLE
Fix typos and improve readability of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Vector-Spaces-and-Matrices
-This project written in C++ privodes template classes to represent vectors and matrices. 
+This project written in C++ provides template classes to represent vectors and matrices. 
 
 Existing features includes vector addition, scalar multiplication, matrix multiplication, matrix determinants, and matrix transformations of vectors.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vector-Spaces-and-Matrices
 This project written in C++ provides template classes to represent vectors and matrices. 
 
-Existing features includes vector addition, scalar multiplication, matrix multiplication, matrix determinants, and matrix transformations of vectors.
+Existing features include vector addition, scalar multiplication, matrix multiplication, matrix determinants, and matrix transformations of vectors.
 
 ### Motivation: ###
 - Learn to implement templates in C++

--- a/README.md
+++ b/README.md
@@ -1,30 +1,25 @@
 # Vector-Spaces-and-Matrices
-Template classes to represent vectors and matrices written in C++. 
+This project written in C++ privodes template classes to represent vectors and matrices. 
 
-Currently offers vector addition, scalar multiplication, matrix multiplication, matrix determinants, and matrix transformations of vectors.
+Existing features includes vector addition, scalar multiplication, matrix multiplication, matrix determinants, and matrix transformations of vectors.
 
 ### Motivation: ###
-- Learning to implement templates in C++
-- Test and improve ability to abstract commonalities correctly
-- Apply and extend knowledge of linear algebra 
+- Learn to implement templates in C++
+- Extend and apply knowledge of linear algebra 
+- Test on and improve ability to abstract commonalities
 
 ### How to use: ###
 
-The templated classes provided are as a `Vector<typename Field, int dim>` and `Matrix<typename Field, int row, int col>` where:
-- Field is the mathematical field that the vector space is over (e.g. in main, "double" is the type used here to represent the Real numbers)
-- dim is the dimension of the vector 
-- row and col are the number of rows and columns of the Matrix, respectively. 
+The template classes provided are as a `Vector<typename Field, int dim>` and `Matrix<typename Field, int row, int col>` where:
+- *Field* means the mathematical field that the vector space is over (e.g. in main, "double" is the type used to represent the Real numbers)
+- *dim* is the dimension of the vector 
+- *row* and *col* are the number of rows and columns of the Matrix, respectively. 
 
-The operators + and * are overloaded appropriately and examples are included in main.cpp. Examples using other Fields (e.g. complex numbers, Z mod p, etc.) are planned.
+The operators *+* and * are overloaded and examples are included in main.cpp. Examples using other Fields (e.g. complex numbers, Z mod p, etc.) are on plan.
 
 ### Future: ###
 
-Plans include:
+Plan to include:
 - Implementing the set of finite fields of prime order, i.e. &#8484; &#8725; &#119901;&#8484; (i.e. the integers modulo p) with p prime, as another templated class
-- Reduced row echelon form for matrices 
+- Reducing row echelon form for matrices
 - Using row echeclon form for faster determinant calculations
-
-
-
-
-


### PR DESCRIPTION
- "Template classes to represent vectors and matrices written in C++" -> "This project written in C++ provides template classes to represent vectors and matrices." (make the sentence complete and concise)
- "Currently offers" -> "Existing features include" (gives the subject of the sentence)
-  (Under Motivation) re-organized the order to "learn", "extend", "apply", "test", "improve" (make things happen logically)
- "test and .... correctly" -> remove "correctly" (no one all want them to be incorrect :D so just remove it)
- "templated classes" -> "template classes" (small typo, template is a noun) 
- "are planned" -> "are on plan" (avoid using passive voice and try to make it more formal)
- Made the bullets of the last part (Future) consistent